### PR TITLE
Use a matrix solver to perform horizontal extrapolation

### DIFF
--- a/ismip6_ocean_forcing/bedmap2/remap.py
+++ b/ismip6_ocean_forcing/bedmap2/remap.py
@@ -5,7 +5,7 @@ import zipfile
 
 from ismip6_ocean_forcing.io import download_files
 from ismip6_ocean_forcing.remap.interp1d import weights_and_indices, interp2d
-from ismip6_ocean_forcing.remap.res import get_res
+from ismip6_ocean_forcing.remap.res import get_horiz_res
 
 
 def bedmap2_to_ismip6_grid(config):
@@ -18,7 +18,7 @@ def bedmap2_to_ismip6_grid(config):
     except OSError:
         pass
 
-    res = get_res(config)
+    res = get_horiz_res(config)
 
     inFileName = 'bedmap2/bedmap2.nc'
     outGridFileName = 'ismip6/{}_grid.nc'.format(res)

--- a/ismip6_ocean_forcing/config.default
+++ b/ismip6_ocean_forcing/config.default
@@ -33,8 +33,10 @@ dzFinal = -60.
 ## basins
 
 # the radius (in meters) of the Gaussian kernel used for local averaging in
-# the horizontal extrapolation
-kernelRadius = 25e3
+# the horizontal extrapolation for valid and invalid source points,
+# respectively
+validKernelRadius = 100e3
+invalidKernelRadius = 12e3
 
 
 [climatology]

--- a/ismip6_ocean_forcing/extrap/vert.py
+++ b/ismip6_ocean_forcing/extrap/vert.py
@@ -13,15 +13,13 @@ def extrap_vert(config, inFileName, outFileName, fieldName, timeIndices=None):
     if 'time' in ds.dims and timeIndices is not None:
         ds = ds.isel(time=timeIndices)
 
-
     nz = ds.sizes['z']
-
 
     field3D = ds[fieldName].values
     origShape = field3D.shape
 
     if 'time' in ds.dims:
-        nt = ds.sizes['times']
+        nt = ds.sizes['time']
     else:
         nt = 1
         field3D = field3D.reshape((1, origShape[0], origShape[1],

--- a/ismip6_ocean_forcing/imbie/extend.py
+++ b/ismip6_ocean_forcing/imbie/extend.py
@@ -5,9 +5,9 @@ import skfmm
 import os
 
 
-def extend_imbie_masks(basins, bedFileName):
+def extend_imbie_masks(res, basins, bedFileName):
 
-    outFileName = 'imbie/basinNumbers.nc'
+    outFileName = 'imbie/basinNumbers_{}.nc'.format(res)
     if os.path.exists(outFileName):
         return
 
@@ -33,7 +33,7 @@ def extend_imbie_masks(basins, bedFileName):
     basinNumber = -1*numpy.zeros((ny, nx), int)
     for index, basinName in enumerate(basinNames):
         print('    {}'.format(basinName))
-        imageFileName = 'imbie/basins/{}.png'.format(basinName)
+        imageFileName = 'imbie/basins_{}/{}.png'.format(res, basinName)
         image = misc.imread(imageFileName)
         basinFraction = 1. - image[::-1, :, 0]/255.
         distance = skfmm.distance(-2.*basinFraction + 1)

--- a/ismip6_ocean_forcing/imbie/images.py
+++ b/ismip6_ocean_forcing/imbie/images.py
@@ -8,9 +8,9 @@ import matplotlib.pyplot as plt
 from ismip6_ocean_forcing.remap.polar import to_polar
 
 
-def write_basin_images(inFileName):
+def write_basin_images(res, inFileName):
 
-    if os.path.exists('imbie/basins/'):
+    if os.path.exists('imbie/basins_{}/'.format(res)):
         return
 
     basinFileName = 'imbie/AntarcticBasins.geojson'
@@ -29,7 +29,7 @@ def write_basin_images(inFileName):
     dx = (ds.x[1] - ds.x[0]).values
 
     try:
-        os.makedirs('imbie/basins')
+        os.makedirs('imbie/basins_{}'.format(res))
     except OSError:
         pass
 
@@ -37,7 +37,7 @@ def write_basin_images(inFileName):
     for index in range(len(basinShapes)):
         name = basinData['features'][index]['properties']['name']
         print('    {}'.format(name))
-        _write_basin_image(basinShapes[index], name, nx, ny, dx)
+        _write_basin_image(res, basinShapes[index], name, nx, ny, dx)
 
 
 def _make_polar_basins(basinData):
@@ -62,7 +62,7 @@ def _make_polar_basins(basinData):
     return basinShapes
 
 
-def _write_basin_image(basinShape, name, nx, ny, dx):
+def _write_basin_image(res, basinShape, name, nx, ny, dx):
     my_dpi = 600
     fig = plt.figure(figsize=(nx/float(my_dpi), ny/float(my_dpi)), dpi=my_dpi)
     ax = plt.Axes(fig, [0., 0., 1., 1.])
@@ -81,5 +81,5 @@ def _write_basin_image(basinShape, name, nx, ny, dx):
     plt.xlim([-dx*0.5*(nx+1), dx*0.5*(nx+1)])
     plt.ylim([-dx*0.5*(ny+1), dx*0.5*(ny+1)])
     fig.canvas.draw()
-    plt.savefig('imbie/basins/{}.png'.format(name), dpi=my_dpi)
+    plt.savefig('imbie/basins_{}/{}.png'.format(res, name), dpi=my_dpi)
     plt.close()

--- a/ismip6_ocean_forcing/imbie/make_imbie_masks.py
+++ b/ismip6_ocean_forcing/imbie/make_imbie_masks.py
@@ -1,19 +1,22 @@
 import os
 
 from ismip6_ocean_forcing.imbie import geojson, images, extend
-from ismip6_ocean_forcing.remap.res import get_res
+from ismip6_ocean_forcing.remap.res import get_horiz_res
+
 
 def make_imbie_masks(config):
     '''
     Download geojson files defining IMBIE basins and create masks that extend
     these basins into the open ocean
     '''
+    res = get_horiz_res(config)
+
     try:
         os.makedirs('imbie')
     except OSError:
         pass
 
-    if os.path.exists('imbie/basinNumbers.nc'):
+    if os.path.exists('imbie/basinNumbers_{}.nc'.format(res)):
         # we're already done
         return
 
@@ -22,14 +25,13 @@ def make_imbie_masks(config):
     basins = [[1, 2, 3], 4, 5, 6, 7, 8, [9, 10, 11], 12, 13, 14, 15, 16,
               [17, 18, 19], 20, 21, 22, 23, 24, 25, 26, 27]
 
-    res = get_res(config)
     bedFileName = 'bedmap2/bedmap2_{}.nc'.format(res)
 
     geojson.download_imbie()
 
     geojson.combine_imbie(basins)
 
-    images.write_basin_images(bedFileName)
+    images.write_basin_images(res, bedFileName)
 
-    extend.extend_imbie_masks(basins, bedFileName)
+    extend.extend_imbie_masks(res, basins, bedFileName)
     print('  Done.')

--- a/ismip6_ocean_forcing/model/anomaly.py
+++ b/ismip6_ocean_forcing/model/anomaly.py
@@ -38,7 +38,7 @@ def _combine_model_output(config):
                folders.split(',')]
 
     try:
-        os.makedirs('outFolder')
+        os.makedirs(outFolder)
     except OSError:
         pass
 
@@ -68,6 +68,11 @@ def _compute_climatology(config):
     inFolder = '{}/{}'.format(baseFolder, config.get('combine', 'outFolder'))
     outFolder = '{}/{}'.format(baseFolder, config.get('climatology', 'folder'))
 
+    try:
+        os.makedirs(outFolder)
+    except OSError:
+        pass
+
     print('  Computing present-day climatology...')
     for fieldName in ['temperature', 'salinity']:
         inFileName = '{}/{}_{}_{}.nc'.format(
@@ -94,6 +99,11 @@ def _compute_anomaly(config):
     climFolder = '{}/{}'.format(baseFolder,
                                 config.get('climatology', 'folder'))
     outFolder = '{}/{}'.format(baseFolder, config.get('anomaly', 'folder'))
+
+    try:
+        os.makedirs(outFolder)
+    except OSError:
+        pass
 
     print('  Computing anomaly from present-day...')
     for fieldName in ['temperature', 'salinity']:
@@ -124,6 +134,11 @@ def _add_anomaly_to_woa(config):
     inFolder = '{}/{}'.format(baseFolder, config.get('anomaly', 'folder'))
     outFolder = '{}/{}'.format(baseFolder, config.get('anomaly', 'woaFolder'))
 
+    try:
+        os.makedirs(outFolder)
+    except OSError:
+        pass
+
     print('  Adding WOA climatology to the anomaly...')
     for fieldName in ['temperature', 'salinity']:
         woaFileName = \
@@ -147,7 +162,7 @@ def _add_anomaly_to_woa(config):
 
 
 def _compute_thermal_driving(config):
-    res = get_res(config)
+    res = get_res(config, extrap=False)
     modelName = config.get('model', 'name')
     subfolder = config.get('anomaly', 'woaFolder')
     modelFolder = '{}/{}'.format(modelName.lower(), subfolder)

--- a/ismip6_ocean_forcing/model/extrap.py
+++ b/ismip6_ocean_forcing/model/extrap.py
@@ -1,9 +1,11 @@
 import os
 
 from ismip6_ocean_forcing.model import remap
-from ismip6_ocean_forcing.extrap.horiz import make_3D_bed_mask, extrap_horiz
+from ismip6_ocean_forcing.extrap.horiz import make_3D_bed_mask, extrap_horiz, \
+    extrap_grounded_above_sea_level
 from ismip6_ocean_forcing.extrap.vert import extrap_vert
-from ismip6_ocean_forcing.remap.res import get_res
+from ismip6_ocean_forcing.remap.res import get_res, get_horiz_res
+from ismip6_ocean_forcing.remap.interp1d import remap_vertical
 
 
 def extrapolate_model(config):
@@ -32,23 +34,25 @@ def extrapolate_model(config):
 
 def _extrap_model(config, modelFolder):
 
-    res = get_res(config)
+    resExtrap = get_res(config, extrap=True)
+    resFinal = get_res(config, extrap=False)
+    hres = get_horiz_res(config)
     modelName = config.get('model', 'name')
 
     inFileName = '{}/{}_temperature_{}.nc'.format(
-        modelFolder, modelName, res)
+        modelFolder, modelName, resExtrap)
     bedMaskFileName = '{}/bed_mask_{}.nc'.format(
-        modelFolder, res)
-    bedFileName = 'bedmap2/bedmap2_{}.nc'.format(res)
-    basinNumberFileName = 'imbie/basinNumbers.nc'
+        modelFolder, resExtrap)
+    bedFileName = 'bedmap2/bedmap2_{}.nc'.format(hres)
+    basinNumberFileName = 'imbie/basinNumbers_{}.nc'.format(hres)
 
     make_3D_bed_mask(inFileName, bedMaskFileName, bedFileName)
 
     for fieldName in ['temperature', 'salinity']:
         inFileName = '{}/{}_{}_{}.nc'.format(
-            modelFolder, modelName, fieldName, res)
+            modelFolder, modelName, fieldName, resExtrap)
         outFileName = '{}/{}_{}_{}_extrap_horiz.nc'.format(
-            modelFolder, modelName, fieldName, res)
+            modelFolder, modelName, fieldName, resExtrap)
 
         progressDir = '{}/progress_{}'.format(modelFolder, fieldName)
         matrixDir = '{}/matrices'.format(modelName.lower())
@@ -58,9 +62,33 @@ def _extrap_model(config, modelFolder):
 
     for fieldName in ['temperature', 'salinity']:
         inFileName = '{}/{}_{}_{}_extrap_horiz.nc'.format(
-            modelFolder, modelName, fieldName, res)
+            modelFolder, modelName, fieldName, resExtrap)
 
         outFileName = '{}/{}_{}_{}_extrap_vert.nc'.format(
-            modelFolder, modelName, fieldName, res)
+            modelFolder, modelName, fieldName, resExtrap)
 
         extrap_vert(config, inFileName, outFileName, fieldName)
+
+    inFileNames = {}
+    outFileNames = {}
+    for fieldName in ['temperature', 'salinity']:
+
+        inFileNames[fieldName] = '{}/{}_{}_{}_extrap_vert.nc'.format(
+            modelFolder, modelName, fieldName, resExtrap)
+        outFileNames[fieldName] = '{}/{}_{}_{}_extrap_vert.nc'.format(
+            modelFolder, modelName, fieldName, resFinal)
+
+    remap_vertical(config, inFileNames, outFileNames, extrap=False)
+
+    for fieldName in ['temperature', 'salinity']:
+
+        inFileName = '{}/{}_{}_{}_extrap_vert.nc'.format(
+            modelFolder, modelName, fieldName, resFinal)
+
+        outFileName = '{}/{}_{}_{}.nc'.format(
+            modelFolder, modelName, fieldName, resFinal)
+
+        progressDir = '{}/progress_{}'.format(modelFolder, fieldName)
+        matrixDir = '{}/matrices'.format(modelName.lower())
+        extrap_grounded_above_sea_level(config, inFileName, outFileName,
+                                        fieldName, progressDir, matrixDir)

--- a/ismip6_ocean_forcing/remap/res.py
+++ b/ismip6_ocean_forcing/remap/res.py
@@ -1,6 +1,19 @@
-def get_res(config):
-    res = config.getfloat('grid', 'dx')/1000.
-    if res == int(res):
-        res = int(res)
-    res = '{}km'.format(res)
+
+def get_horiz_res(config):
+    hres = config.getfloat('grid', 'dx')/1000.
+    if hres == int(hres):
+        hres = int(hres)
+    res = '{}km'.format(hres)
+    return res
+
+
+def get_res(config, extrap=True):
+    hres = get_horiz_res(config)
+    if extrap:
+        vres = -config.getfloat('grid', 'dzExtrap')
+    else:
+        vres = -config.getfloat('grid', 'dzFinal')
+    if vres == int(vres):
+        vres = int(vres)
+    res = '{}_x_{}m'.format(hres, vres)
     return res

--- a/ismip6_ocean_forcing/thermal_forcing/main.py
+++ b/ismip6_ocean_forcing/thermal_forcing/main.py
@@ -23,7 +23,7 @@ def compute_thermal_forcing(temperatureFileName, salinityFileName, outFileName,
     nz = dsTemp.sizes['z']
 
     if 'time' in dsTemp.dims:
-        nt = dsTemp.sizes['times']
+        nt = dsTemp.sizes['time']
     else:
         nt = 1
 

--- a/ismip6_ocean_forcing/woa/extrap.py
+++ b/ismip6_ocean_forcing/woa/extrap.py
@@ -1,22 +1,29 @@
-from ismip6_ocean_forcing.extrap.horiz import make_3D_bed_mask, extrap_horiz
+from ismip6_ocean_forcing.extrap.horiz import make_3D_bed_mask, extrap_horiz, \
+    extrap_grounded_above_sea_level
 from ismip6_ocean_forcing.extrap.vert import extrap_vert
-from ismip6_ocean_forcing.remap.res import get_res
+from ismip6_ocean_forcing.remap.res import get_res, get_horiz_res
+from ismip6_ocean_forcing.remap.interp1d import remap_vertical
+from ismip6_ocean_forcing.thermal_forcing.main import compute_thermal_forcing
 
 
 def extrap_woa(config):
 
-    res = get_res(config)
-    inFileName = 'woa/woa_temperature_1995-2012_{}.nc'.format(res)
-    bedMaskFileName = 'woa/bed_mask_{}.nc'.format(res)
-    bedFileName = 'bedmap2/bedmap2_{}.nc'.format(res)
-    basinNumberFileName = 'imbie/basinNumbers.nc'
+    resExtrap = get_res(config, extrap=True)
+    resFinal = get_res(config, extrap=False)
+    hres = get_horiz_res(config)
+
+
+    inFileName = 'woa/woa_temperature_1995-2012_{}.nc'.format(resExtrap)
+    bedMaskFileName = 'woa/bed_mask_{}.nc'.format(resExtrap)
+    bedFileName = 'bedmap2/bedmap2_{}.nc'.format(hres)
+    basinNumberFileName = 'imbie/basinNumbers_{}.nc'.format(hres)
 
     make_3D_bed_mask(inFileName, bedMaskFileName, bedFileName)
 
     for fieldName in ['temperature', 'salinity']:
-        inFileName = 'woa/woa_{}_1995-2012_{}.nc'.format(fieldName, res)
-        outFileName = \
-            'woa/woa_{}_1995-2012_{}_extrap_horiz.nc'.format(fieldName, res)
+        inFileName = 'woa/woa_{}_1995-2012_{}.nc'.format(fieldName, resExtrap)
+        outFileName = 'woa/woa_{}_1995-2012_{}_extrap_horiz.nc'.format(
+                fieldName, resExtrap)
 
         progressDir = 'woa/progress_{}'.format(fieldName)
         matrixDir = 'woa/matrices'
@@ -25,10 +32,44 @@ def extrap_woa(config):
                      matrixDir)
 
     for fieldName in ['temperature', 'salinity']:
-        inFileName = \
-            'woa/woa_{}_1995-2012_{}_extrap_horiz.nc'.format(fieldName, res)
+        inFileName = 'woa/woa_{}_1995-2012_{}_extrap_horiz.nc'.format(
+                fieldName, resExtrap)
 
-        outFileName = \
-            'woa/woa_{}_1995-2012_{}_extrap_vert.nc'.format(fieldName, res)
+        outFileName = 'woa/woa_{}_1995-2012_{}_extrap_vert.nc'.format(
+                fieldName, resExtrap)
 
         extrap_vert(config, inFileName, outFileName, fieldName)
+
+    tempFileName = \
+        'woa/woa_temperature_1995-2012_{}_extrap_vert.nc'.format(resExtrap)
+    salinFileName = \
+        'woa/woa_salinity_1995-2012_{}_extrap_vert.nc'.format(resExtrap)
+    outFileName = \
+        'woa/woa_thermal_forcing_1995-2012_{}_extrap_vert.nc'.format(resExtrap)
+    compute_thermal_forcing(tempFileName, salinFileName, outFileName)
+
+    inFileNames = {}
+    outFileNames = {}
+    for fieldName in ['temperature', 'salinity']:
+
+        inFileNames[fieldName] = \
+            'woa/woa_{}_1995-2012_{}_extrap_vert.nc'.format(
+                fieldName, resExtrap)
+
+        outFileNames[fieldName] = \
+            'woa/woa_{}_1995-2012_{}_extrap_vert.nc'.format(
+                fieldName, resFinal)
+
+    remap_vertical(config, inFileNames, outFileNames, extrap=False)
+
+    for fieldName in ['temperature', 'salinity']:
+
+        inFileName = 'woa/woa_{}_1995-2012_{}_extrap_vert.nc'.format(
+                fieldName, resFinal)
+
+        outFileName = 'woa/woa_{}_1995-2012_{}.nc'.format(fieldName, resFinal)
+
+        progressDir = 'woa/progress_{}'.format(fieldName)
+        matrixDir = 'woa/matrices'
+        extrap_grounded_above_sea_level(config, inFileName, outFileName,
+                                        fieldName, progressDir, matrixDir)

--- a/ismip6_ocean_forcing/woa/main.py
+++ b/ismip6_ocean_forcing/woa/main.py
@@ -15,7 +15,7 @@ def extrapolate_woa(config):
     except OSError:
         pass
 
-    res = get_res(config)
+    resFinal = get_res(config, extrap=False)
 
     print('Extrapolate World Ocean Atlas...')
 
@@ -41,11 +41,11 @@ def extrapolate_woa(config):
     extrap.extrap_woa(config)
 
     tempFileName = \
-        'woa/woa_temperature_1995-2012_{}_extrap_vert.nc'.format(res)
+        'woa/woa_temperature_1995-2012_{}.nc'.format(resFinal)
     salinFileName = \
-        'woa/woa_salinity_1995-2012_{}_extrap_vert.nc'.format(res)
+        'woa/woa_salinity_1995-2012_{}.nc'.format(resFinal)
     outFileName = \
-        'woa/woa_thermal_forcing_1995-2012_{}_extrap_vert.nc'.format(res)
+        'woa/woa_thermal_forcing_1995-2012_{}.nc'.format(resFinal)
     compute_thermal_forcing(tempFileName, salinFileName, outFileName)
 
     print('  Done.')

--- a/ismip6_ocean_forcing/woa/remap.py
+++ b/ismip6_ocean_forcing/woa/remap.py
@@ -9,7 +9,7 @@ from ismip6_ocean_forcing.remap.descriptor import get_antarctic_descriptor, \
     get_lat_lon_descriptor
 
 from ismip6_ocean_forcing.remap.remapper import Remapper
-from ismip6_ocean_forcing.remap.res import get_res
+from ismip6_ocean_forcing.remap.res import get_res, get_horiz_res
 
 
 def remap_woa(config):
@@ -120,6 +120,7 @@ def _interp_z(config):
 def _remap(config):
 
     res = get_res(config)
+    hres = get_horiz_res(config)
     bothExist = True
     for fieldName in ['temperature', 'salinity']:
         outFileName = 'woa/woa_{}_1995-2012_{}.nc'.format(fieldName, res)
@@ -132,7 +133,7 @@ def _remap(config):
     print('  Remapping to {} grid...'.format(res))
     for field, fieldName in [['t', 'temperature'], ['s', 'salinity']]:
         inFileName = 'woa/woa13_95B2_{}00_04v2_interp_z.nc'.format(field)
-        outGridFileName = 'ismip6/{}_grid.nc'.format(res)
+        outGridFileName = 'ismip6/{}_grid.nc'.format(hres)
         outFileName = 'woa/woa_{}_1995-2012_{}.nc'.format(fieldName, res)
         print('    {}'.format(outFileName))
 


### PR DESCRIPTION
Since some files are at 20 m vert res and some are at 60 m, the
vert res is part of the file name.

The algorithm for horizontal extrapolation has been modified so
valid cells are averaged over a large area (100 km by default) but
invalid cells are averaged over a smaller area (12 km by default)
for numerical efficiency.

Extrapolation is now performed into regions grounded above sea
level at the end to prevent NaNs from causing trouble for models
with topographies that differ from Bedmap2.