### PR TITLE
Make valid masks for ocean extrapolation overlap between IMBIE basins

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ the required packages as follows:
 ```bash
 conda create -n ismip6_ocean_forcing -c conda-forge python=3.6 numpy scipy \
     matplotlib netCDF4 xarray progressbar2 basemap descartes cartopy shapely \
-    nco gsw
+    nco gsw scikit-fmm
 ```
 
 If you need help installing `conda`,

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -38,6 +38,7 @@ requirements:
         - shapely
         - nco
         - gsw
+        - scikit-fmm
 about:
     home:  http://gitub.com/xylar/ismip6-ocean-forcing
     license: MIT

--- a/ismip6_ocean_forcing/woa/extrap.py
+++ b/ismip6_ocean_forcing/woa/extrap.py
@@ -12,7 +12,6 @@ def extrap_woa(config):
     resFinal = get_res(config, extrap=False)
     hres = get_horiz_res(config)
 
-
     inFileName = 'woa/woa_temperature_1995-2012_{}.nc'.format(resExtrap)
     bedMaskFileName = 'woa/bed_mask_{}.nc'.format(resExtrap)
     bedFileName = 'bedmap2/bedmap2_{}.nc'.format(hres)

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,6 @@ setup(name='ismip6_ocean_forcing',
       package_data={'ismip6_ocean_forcing': ['config.default']},
       install_requires=['numpy', 'scipy', 'matplotlib', 'netCDF4', 'xarray',
                         'progressbar2', 'basemap', 'descartes', 'cartopy',
-                        'shapely', 'gsw'],
+                        'shapely', 'gsw', 'scikit-fmm'],
       entry_points={'console_scripts':
                     ['ismip6_ocean_forcing = ismip6_ocean_forcing.__main__:main']})


### PR DESCRIPTION
Allow extension of IMBIE basins into the ocean for purposes of horizontal extrapolation to overlap (unlike for ice-sheet models) because otherwise some basins don't have enough coverage in the open ocean.