### PR TITLE
 Bug fix: include open ocean in flood fill

### DIFF
--- a/ismip6_ocean_forcing/__main__.py
+++ b/ismip6_ocean_forcing/__main__.py
@@ -19,6 +19,7 @@ from ismip6_ocean_forcing.woa.main import extrapolate_woa
 from ismip6_ocean_forcing.model.extrap import extrapolate_model
 from ismip6_ocean_forcing.model.anomaly import compute_anomaly_and_to_woa
 
+
 def main():
 
     parser = argparse.ArgumentParser(

--- a/ismip6_ocean_forcing/config.default
+++ b/ismip6_ocean_forcing/config.default
@@ -39,6 +39,13 @@ validKernelRadius = 100e3
 invalidKernelRadius = 12e3
 
 
+[woa]
+## Config options related to World Ocean Atlas extrapolation
+
+# Extrapolate WOA temperatuer and salinity data?
+compute = True
+
+
 [climatology]
 ## The range of time indices to use in climatology defining "present-day"
 # Should likely be the range of 1995-2012 to match the WOA climatology
@@ -63,6 +70,9 @@ zIndexMax = -1
 
 [model]
 ## Config options related to the model to extrapolate forcing for
+
+# Compute model forcing
+compute = True
 
 # The name of the model.  A lower-case version of this name is the folder
 # where all model data is stored

--- a/ismip6_ocean_forcing/model/extrap.py
+++ b/ismip6_ocean_forcing/model/extrap.py
@@ -14,6 +14,9 @@ def extrapolate_model(config):
     IMBIE basins. Ten, compute thermal forcing.
     '''
 
+    if not config.getboolean('model', 'compute'):
+        return
+
     modelName = config.get('model', 'name')
     subfolder = config.get('model', 'folder')
     modelFolder = '{}/{}'.format(modelName.lower(), subfolder)

--- a/ismip6_ocean_forcing/woa/main.py
+++ b/ismip6_ocean_forcing/woa/main.py
@@ -10,6 +10,10 @@ def extrapolate_woa(config):
     Download WOA 13 v2 temperature and salinity, and extrapolate them into
     ice-shelf cavities and IMBIE basins
     '''
+
+    if not config.getboolean('woa', 'compute'):
+        return
+
     try:
         os.makedirs('woa')
     except OSError:


### PR DESCRIPTION
Without the open ocean, the flood fill used to compute the fill
region for each basin will usually lead to an empty mask.

Also, use the overlapping basin mask computed by extending the
IMBIE basins by 300 km rather than the non-overlapping extended
basins for use by ice sheet models.

Make WOA and model extrap. optional each is controlled by a boolean "compute" option