### PR TITLE
Add support for parallelism within the horizontal extrapolation

### DIFF
--- a/ismip6_ocean_forcing/config.default
+++ b/ismip6_ocean_forcing/config.default
@@ -35,8 +35,14 @@ dzFinal = -60.
 # the radius (in meters) of the Gaussian kernel used for local averaging in
 # the horizontal extrapolation for valid and invalid source points,
 # respectively
-validKernelRadius = 100e3
+validKernelRadius = 150e3
 invalidKernelRadius = 12e3
+
+[parallel]
+## options related to running parts of the process in parallel
+
+# the number of parallel tasks
+tasks = 1
 
 
 [woa]


### PR DESCRIPTION
A config option is available for the number of parallel tasks, which defaults to 1.

This merge also fixes a bug where the domain for extrapolation was not correctly being masked based on the bathymetry.