### PR TITLE
Fix extrapolation

### DIFF
--- a/ismip6_ocean_forcing/config.default
+++ b/ismip6_ocean_forcing/config.default
@@ -32,14 +32,12 @@ dzFinal = -60.
 ## Config options related to extrapolation into ice-shelf cavities and IMBIE
 ## basins
 
-# the radius (in meters) of the Gaussian kernel used for local averaging in
-# the horizontal extrapolation for valid and invalid source points,
-# respectively
-validKernelRadius = 8e3
-invalidKernelRadius = 8e3
+# the radius (in meters) of the Gaussian kernel used for local smoothing after
+# the horizontal extrapolation
+smoothingKernelRadius = 8e3
 
-# the number of smoothing iterations to perform on the valid data
-validSmoothingIterations = 30
+# the number of smoothing iterations to perform on the data after extrapolation
+smoothingIterations = 30
 
 [parallel]
 ## options related to running parts of the process in parallel

--- a/ismip6_ocean_forcing/extrap/horiz.py
+++ b/ismip6_ocean_forcing/extrap/horiz.py
@@ -117,8 +117,8 @@ def extrap_horiz(config, inFileName, outFileName, fieldName, bedmap2FileName,
         dsBasinMasks = xarray.Dataset()
         for basinNumber in range(basinCount):
             basinMask = _compute_valid_basin_mask(
-                    basinNumbers, basinNumber, openOceanMask,
-                    continentalShelfMask, dx)
+                basinNumbers, basinNumber, openOceanMask,
+                continentalShelfMask, dx)
             dsBasinMasks['basin{}Mask'.format(basinNumber)] = \
                 (('y', 'x'), basinMask)
         dsBasinMasks.to_netcdf(basinMaskFileName)

--- a/ismip6_ocean_forcing/extrap/horiz.py
+++ b/ismip6_ocean_forcing/extrap/horiz.py
@@ -345,7 +345,7 @@ def _write_basin_matrices(ds, fieldName, basinName, openOceanMask, validMask,
         for zIndex, _ in enumerate(pool.imap(partial_func, zIndices)):
             bar.update(zIndex+1)
         bar.finish()
-        del pool
+        pool.terminate()
 
 
 def _write_level_basin_matrix(matrixFileTemplate, field3D, bedMask, validMask,
@@ -468,7 +468,7 @@ def _extrap_basin(ds, fieldName, basinName, matrixFileTemplate, parallelTasks,
             bar.update(zIndex+1)
 
         bar.finish()
-        del pool
+        pool.terminate()
 
     if 'time' not in ds.dims:
         field3D = field3D.reshape(origShape)


### PR DESCRIPTION
Changes the extrapolation algorithm:
1. Extrapolate/interpolate only locally (3x3 kernel), leaving valid
   values alone.
2. Smooth both valid and invalid with a small Gaussian kernel (7x7,
   I think) over 30 iterations (~150 km) with masking at each
   iteration

Terminate pool so threads are killed and deallocated
